### PR TITLE
feat: conditionally allow GITHUB_ALLOWED_USERS to be pulled from secrets manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ artillery set-config-value --name GITHUB_ALLOWED_ORGS --value '["artilleryio"]'
 artillery set-config-value --name GITHUB_ALLOWED_USERS --value '[]'
 ```
 
+#### GITHUB_ALLOWED_USERS in Secrets Manager instead of SSM Parameter Store
+
+The command listed above creates the config value in SSM Parameter Store, which is the default way of using this. However, since SSM Parameter Store has a 4-8 KB limitation in the size of the secret, you may hit this limit if you want to allow a sufficiently large user base, and `GITHUB_ALLOWED_ORGS` doesn't work for you (e.g. if users in your org don't have a public profile enabled by default).
+
+In that case, you will need to:
+1. Create a **Plaintext Secret** in Secrets Manager, called `/artilleryio/GITHUB_ALLOWED_USERS`, in the same AWS region as your deployment.
+2. The secret will look the same as the SSM secret described above, a list of users, e.g. `["hassy", "dino"]`. 
+3. When deploying the dashboard, make sure to set the environment variable `USE_SECRETS_MANAGER_FOR_GITHUB_USERS=true` before your `cdk deploy` command.
+
 #### `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
 
 These need to be set to a valid client ID and client secret for a GitHub OAuth app. See [GitHub docs](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) for details on how to create an app. **Note:** set "Authorization Callback URL" to `http://localhost` initially. You will update this setting with the actual URL of Artillery dashboard once you've deployed it.

--- a/lib/control-panel-deploy-cdk-stack.js
+++ b/lib/control-panel-deploy-cdk-stack.js
@@ -186,7 +186,18 @@ VPC CIDR:    ${vpc.vpcCidrBlock}`);
                 `arn:aws:ssm:${this.region}:${this.accountId}:parameter/artilleryio/*`,
               ],
             }),
-          ],
+            (process.env.USE_SECRETS_MANAGER_FOR_GITHUB_USERS) ?
+              new iam.PolicyStatement({
+                actions: [
+                  'secretsmanager:GetSecretValue',
+                  'secretsmanager:DescribeSecret',
+                ],
+                resources: [
+                  `arn:aws:secretsmanager:${this.region}:${this.accountId}:secret:/artilleryio/GITHUB_ALLOWED_USERS`,
+                  `arn:aws:secretsmanager:${this.region}:${this.accountId}:secret:/artilleryio/GITHUB_ALLOWED_USERS/*`,
+                ]
+              }) : undefined
+          ].filter(item => item !== undefined),
         }),
       },
     });
@@ -252,13 +263,20 @@ VPC CIDR:    ${vpc.vpcCidrBlock}`);
           { parameterName: '/artilleryio/GITHUB_CLIENT_SECRET' },
         ),
       ),
-      GITHUB_ALLOWED_USERS: ecs.Secret.fromSsmParameter(
-        ssm.StringParameter.fromStringParameterAttributes(
-          this,
-          'github-allowed-users',
-          { parameterName: '/artilleryio/GITHUB_ALLOWED_USERS' },
+      GITHUB_ALLOWED_USERS: (process.env.USE_SECRETS_MANAGER_FOR_GITHUB_USERS) ?
+        ecs.Secret.fromSecretsManager(
+          secretsmanager.Secret.fromSecretNameV2(
+            this,
+            'github-allowed-users',
+            '/artilleryio/GITHUB_ALLOWED_USERS',
+          )) :
+        ecs.Secret.fromSsmParameter(
+          ssm.StringParameter.fromStringParameterAttributes(
+            this,
+            'github-allowed-users',
+            { parameterName: '/artilleryio/GITHUB_ALLOWED_USERS' },
+          )
         ),
-      ),
       GITHUB_ALLOWED_ORGS: ecs.Secret.fromSsmParameter(
         ssm.StringParameter.fromStringParameterAttributes(
           this,


### PR DESCRIPTION
**Description:**
As mentioned to Hassy, we ran into the use case of wanting to enable Artillery Dashboard to our entire Github org (>600 github users) by default. Unfortunately, that was a 9KB payload, and SSM only allowed 4-8 KB. This was the proposed alternative, which works and should be backwards compatible.


**Testing:**
- This was tested against a secondary deployment we have of Artillery Dashboard, and it does work.
- I have also ran a `cdk deploy--dry-run` without the env variable `USE_SECRETS_MANAGER_FOR_GITHUB_USERS`, and it appears to work as before