### PR TITLE
fix: add missing require of secretsmanager

### DIFF
--- a/lib/control-panel-deploy-cdk-stack.js
+++ b/lib/control-panel-deploy-cdk-stack.js
@@ -8,6 +8,7 @@ const dynamo = require('aws-cdk-lib/aws-dynamodb');
 const iam = require('aws-cdk-lib/aws-iam');
 const acm = require('aws-cdk-lib/aws-certificatemanager');
 const ssm = require('aws-cdk-lib/aws-ssm');
+const secretsmanager = require('aws-cdk-lib/aws-secretsmanager');
 
 class ControlPanelDeployCdkStack extends Stack {
   /**


### PR DESCRIPTION
Fixes regression introduced here: https://github.com/artilleryio/installer-aws-cdk/pull/4.

This is broken in the main branch, and was an oversight when the fork was created vs my local branch. Just noticed it now when I ran this against my primary deployment (had only tested it against a secondary one). Apologies!

## Testing

I have deployed my primary deployment of Artillery Dashboard using this code.